### PR TITLE
Miscellaneous issues with jquery-encoder

### DIFF
--- a/src/main/javascript/org/owasp/esapi/jquery/encoder.js
+++ b/src/main/javascript/org/owasp/esapi/jquery/encoder.js
@@ -119,16 +119,26 @@
          * @throws String Reports error when attribute name contains invalid characters (unencoded)
          */
         encodeForHTMLAttribute: function(attr,input,omitAttributeName) {
+            // Declaring immune as a local variable. Don't want to share it between the different encode functions.
+            var immune;
             hasBeenInitialized = true;
             // Check for unsafe attributes
             attr = $.encoder.canonicalize(attr).toLowerCase();
             input = $.encoder.canonicalize(input);
 
-            if ( $.inArray(attr, unsafeKeys['attr_name']) >= 0 ) {
-                throw "Unsafe attribute name used: " + attr;
+            // Event handlers like onmouseover should not be allowed as an attribute encoded via this method,
+            // they should be encoded via encodeForJavascript.
+            // The blacklist for attribute names contains a regular expression to identify them, on[a-z]{1,},
+            // but the regular expression is not applied since inArray() in jQuery doesn’t support regular expressions.
+            // Note that the regexp is quite wide, for instance is NonExistingAttributeName a match.
+            for ( var i=0; i < unsafeKeys['attr_name'].length; i++ ) {
+                if ( attr.toLowerCase().match(unsafeKeys['attr_name'][i]) ) {
+                    throw "Unsafe attribute name used: " + attr;
+                }
             }
 
-            for ( var a=0; a < unsafeKeys['attr_val']; a++ ) {
+            // Length has to be added in order to execute the loop that searches for unsafe attribute values.
+            for ( var a=0; a < unsafeKeys['attr_val'].length; a++ ) {
                 if ( input.toLowerCase().match(unsafeKeys['attr_val'][a]) ) {
                     throw "Unsafe attribute value used: " + input;
                 }
@@ -188,6 +198,8 @@
          * @throws String Reports error when illegal characters passed in property name
          */
         encodeForCSS: function(propName,input,omitPropertyName) {
+            // Declaring immune as a local variable. Don't want to share it between the different encode functions.
+            var immune;
             hasBeenInitialized = true;
             // Check for unsafe properties
             propName = $.encoder.canonicalize(propName).toLowerCase();
@@ -271,8 +283,9 @@
          * @param input The untrusted input to be encoded
          */
         encodeForJavascript: function(input) {
+            // Declaring immune as a local variable. Don't want to share it between the different encode functions.
+            var immune = default_immune['js'];
             hasBeenInitialized = true;
-            if ( !immune ) immune = default_immune['js'];
             var encoded = '';
             for (var i=0; i < input.length; i++ ) {
                 var ch = input.charAt(i), cc = input.charCodeAt(i);

--- a/src/test/javascript/qunit-jquery-encoder-test.html
+++ b/src/test/javascript/qunit-jquery-encoder-test.html
@@ -17,6 +17,17 @@
     <!--<script type="text/javascript" src="../../main/javascript/org/owasp/esapi/jquery/encoder.js"></script>-->
     <script type="text/javascript" src="../../../jquery-encoder-0.1.0.js"></script>
     <script type="text/javascript">
+
+        // Additional test added to identify an issue with the jquery-encoder.
+        // Problem is the global variable immune: it is used in encodeForHTMLAttribute, encodeForCSS and encodeForJavascript.
+        // It is not initialized in encodeForJavascript, which leads to random behaviour,
+        // it uses the same immune characters as previous function call, irrespective of which of the encoding functions
+        // that preceded this call, or even worse if not set earlier by someone else an exception is raised.
+        module('Javascript Contextual Encoding');
+        test('Javascript Encoding', function() {
+            equal($.encoder.encodeForJavascript('<b>'), '\\x3Cb\\x3E');
+        });
+
         module('Canonicalize Test Suite');
         var $fn = $.encoder.canonicalize;
 
@@ -124,6 +135,24 @@
             var e = $('#test');
             equal(e.encode('attr', 'a', '<B>').attr('a'), '&#x3c;B&#x3e;');
             equal($.encoder.encodeForHTMLAttribute('a', '<B>'), 'a="&#x3c;B&#x3e;"')
+            // Additional test added to identify an issue with the jquery-encoder.
+            // Event handlers like onmouseover should not be allowed as an attribute encoded via this method,
+            // they should be encoded via encodeForJavascript.
+            // The blacklist for attribute names contains a regular expression to identify them, on[a-z]{1,},
+            // but the regular expression is not applied since inArray() in jQuery doesn’t support regular expressions.
+            raises( function() {
+                $.encoder.encodeForHTMLAttribute('onmouseover', 'alert(xyz)', true);
+            }, 'Invalid html attribute onmouseover');
+            raises( function() {
+                $.encoder.encodeForHTMLAttribute('href', 'alert(xyz)', true);
+            }, 'Invalid html attribute href');
+            // Additional test added to identify an issue with the jquery-encoder.
+            // javascript: isn't recognized as an unsafe attribute value
+            raises( function() {
+                // To prevent JsHint warning for variable value "javascript:" we concat two separate ones. JsHint you fool!
+                var colon = ':', js = "javascript", unsafeValue = js + colon;
+                $.encoder.encodeForHTMLAttribute('a', unsafeValue);
+            }, 'Invalid HTML attribute value javascript:');
         });
 
         module('URL Contextual Encoding');


### PR DESCRIPTION
Hello Chris,
I am using your jquery encoder. Many thanks for developing it!
We have done some unit testings and found some issues. I have made suggestions on how to correct them in this fork.

1) Which characters that are immune was random for javascript encoding,
in worst case it threw an exception. The problem is the global variable immune: it is used in encodeForHTMLAttribute, encodeForCSS and encodeForJavascript.
It is not initialized in encodeForJavascript, which leads to random behaviour,
it uses the same immune characters as previous function call, irrespective of which of the encoding functions that preceded this call, or even worse if not set earlier by someone else an exception is raised.
Solution: I just changed immune from being global to local.

2) Event handlers like onmouseover shouldn't be allowed to be encoded via
function encodeForHTMLAttribute, they should be encoded via encodeForJavascript.
The blacklist for attribute names contains a regular expression to identify them, on[a-z]{1,}, but the regular expression is not applied since inArray() in jQuery doesn’t support regular expressions. Note that the regexp is quite wide, for instance is NonExistingAttributeName a match.
Solution: Changed from inArray() to match().

3) Unsafe html attribute values were not searched for.
Solution: Length has to be added in order to execute the array iteration that searches for unsafe attribute values.

4) From the documentation of function canonicalize: "The default behavior of the method is to raise an exception if it detects one of these scenarios.". This refers to multiple or double encoding. But that is not the case, the default behaviour is to ignore a double encoding. Which behaviour is prefered? 
The default behaviour is important, that one will be used when canonicalize() is called from the other encode functions.

I have extended your unit test to identify issue 1 to 3. If you test against jquery-encoder-0.1.0.js you will get three failures, which are corrected if you test against encoder.js.

Thanks Karin
